### PR TITLE
RichByteBuffer throws ClassCastException in ByteBuffer2BigDecimal

### DIFF
--- a/src/main/scala/com/tuplejump/calliope/utils/RichByteBuffer.scala
+++ b/src/main/scala/com/tuplejump/calliope/utils/RichByteBuffer.scala
@@ -56,7 +56,7 @@ object RichByteBuffer {
 
   implicit def ByteBuffer2ByteArray(buffer: ByteBuffer): Array[Byte] = ByteBufferUtil.getArray(buffer)
 
-  implicit def ByteBuffer2BigDecimal(buffer: ByteBuffer): BigDecimal = DataType.decimal().deserialize(buffer).asInstanceOf[BigDecimal]
+  implicit def ByteBuffer2BigDecimal(buffer: ByteBuffer): BigDecimal = DataType.decimal().deserialize(buffer).asInstanceOf[java.math.BigDecimal]
 
   implicit def ByteBuffer2BigInteger(buffer: ByteBuffer): BigInteger = new BigInteger(ByteBufferUtil.getArray(buffer))
 


### PR DESCRIPTION
With the 0.9.4 snapshot I'm getting the following exception...

```
14/06/19 09:13:18 ERROR Executor: Exception in task ID 786
java.lang.ClassCastException: java.math.BigDecimal cannot be cast to scala.math.BigDecimal
        at com.tuplejump.calliope.utils.RichByteBuffer$.ByteBuffer2BigDecimal(RichByteBuffer.scala:59)
```

We should probably be do the conversion using the implicit method in `scala.collection.JavaConverters` rather than `asInstanceOf` ([more info](http://stackoverflow.com/questions/3412068/what-are-the-differences-between-asinstanceoft-and-o-t-in-scala)). I don't think converting a `java.util.BigDecimal` to a `scala.math.BigDecimal` using `asInstanceOf` will work...

```
wasted:calliope brent$ scala
Welcome to Scala version 2.11.1 (Java HotSpot(TM) 64-Bit Server VM, Java 1.7.0_25).
Type in expressions to have them evaluated.
Type :help for more information.

scala> import scala.collection.JavaConverters._
import scala.collection.JavaConverters._

scala> val jb = new java.math.BigDecimal("3.03")
jb: java.math.BigDecimal = 3.03

scala> val sb = jb.asInstanceOf[BigDecimal]
java.lang.ClassCastException: java.math.BigDecimal cannot be cast to scala.math.BigDecimal
  ... 32 elided

scala> val sb: BigDecimal = jb
sb: BigDecimal = 3.03
```
