### PR TITLE
CQL Java Driver exception when serializing BigDecimals to ByteBuffers

### DIFF
--- a/src/main/scala/com/tuplejump/calliope/utils/RichByteBuffer.scala
+++ b/src/main/scala/com/tuplejump/calliope/utils/RichByteBuffer.scala
@@ -116,7 +116,7 @@ object RichByteBuffer {
 
   implicit def ByteArray2ByteBuffer(bytes: Array[Byte]): ByteBuffer = ByteBuffer.wrap(bytes)
 
-  implicit def BigDecimal2ByteBuffer(bigDec: BigDecimal): ByteBuffer = DataType.decimal().serialize(bigDec)
+  implicit def BigDecimal2ByteBuffer(bigDec: BigDecimal): ByteBuffer = DataType.decimal().serialize(bigDec.bigDecimal)
 
   implicit def BigInteger2ByteBuffer(bigInt: BigInteger): ByteBuffer = bigInt.toByteArray
 


### PR DESCRIPTION
Inverse of issue in #27...

```
org.apache.spark.SparkException: Job aborted due to stage failure: Task 1.0:11 failed 4 times, most recent failure: Exception failure in TID 1614 on host cassandra2.internal.womply.com: com.datastax.driver.core.exceptions.InvalidTypeException: Invalid value for CQL type decimal, expecting class java.math.BigDecimal but class scala.math.BigDecimal provided
        com.datastax.driver.core.DataType.serialize(DataType.java:508)
        com.tuplejump.calliope.utils.RichByteBuffer$.BigDecimal2ByteBuffer(RichByteBuffer.scala:119)
```
