### PR TITLE
Add implicit conversions for option string and double

### DIFF
--- a/src/main/scala/com/tuplejump/calliope/utils/RichByteBuffer.scala
+++ b/src/main/scala/com/tuplejump/calliope/utils/RichByteBuffer.scala
@@ -158,5 +158,39 @@ object RichByteBuffer {
     DataType.list(DataType.text()).deserialize(buffer)
       .asInstanceOf[java.util.List[String]].asScala.toList
 
+
+  /* Conversions for Option */
+
+  implicit def ByteBuffer2OptionString(buffer: ByteBuffer): Option[String] =
+    buffer match {
+      case null => None // Avoid implicitly converting a null into a
+                        // Double 'cause that doesn't work.
+      case _    => Some[String](buffer)
+    }
+
+  implicit def OptionString2ByteBuffer(maybeStr: Option[String]): ByteBuffer =
+    maybeStr match {
+      case None => null: ByteBuffer // Avoid implicitly coverting a
+                                    // null to a ByteBuffer 'cause
+                                    // that doesn't work.
+      case str  => str.getOrElse[String]("")
+    }
+
+
+  implicit def ByteBuffer2OptionDouble(buffer: ByteBuffer): Option[Double] =
+    buffer match {
+      case null => None // Avoid implicitly converting a null into a
+                        // Double 'cause that doesn't work.
+      case _    => Some[Double](buffer)
+    }
+
+  implicit def OptionDouble2ByteBuffer(maybeDbl: Option[Double]): ByteBuffer =
+    maybeDbl match {
+      case None => null: ByteBuffer // Avoid implicitly coverting a
+                                    // null to a ByteBuffer 'cause
+                                    // that doesn't work.
+      case dbl  => dbl.getOrElse[Double](0D)
+    }
+
 }
 

--- a/src/test/scala/com/tuplejump/calliope/RichByteBufferSpec.scala
+++ b/src/test/scala/com/tuplejump/calliope/RichByteBufferSpec.scala
@@ -108,5 +108,48 @@ class RichByteBufferSpec extends FunSpec with ShouldMatchers with MustMatchers {
       newLs must equal(origLs)
     }
 
+    it("should add implicit conversion of non-empty Option[String] to ByteBuffer and vise versa") {
+      val orig = Some("foo")
+
+      val bb: ByteBuffer = orig
+
+      val copy: Option[String] = bb
+
+      copy must equal(orig)
+    }
+
+    it("should add implicit conversion of empty Option[String] to ByteBuffer and vise versa") {
+      val orig: Option[String] = None
+
+      val bb: ByteBuffer = orig
+
+      bb must be(null)
+
+      val copy: Option[String] = bb
+
+      copy must be(None)
+    }
+
+    it("should add implicit conversion of non-empty Option[Double] to ByteBuffer and vise versa") {
+      val orig = Some(1D)
+
+      val bb: ByteBuffer = orig
+
+      val copy: Option[Double] = bb
+
+      copy must equal(orig)
+    }
+
+    it("should add implicit conversion of empty Option[Double] to ByteBuffer and vise versa") {
+      val orig: Option[Double] = None
+
+      val bb: ByteBuffer = orig
+
+      bb must be(null)
+
+      val copy: Option[Double] = bb
+
+      copy must be(None)
+    }
   }
 }


### PR DESCRIPTION
I don't love how much duplication there is in this code but i haven't yet been able to create a working generic version of the to and from conversion functions. If anyone else can see a way to do that i love to see how it is done (for my edification).
